### PR TITLE
Add Shopify collections workflow

### DIFF
--- a/src/workflows/index.ts
+++ b/src/workflows/index.ts
@@ -1,0 +1,4 @@
+export * from "./migrate-products-from-shopify"
+export * from "./steps/get-shopify-products"
+export * from "./migrate-collections-from-shopify"
+export * from "./steps/get-shopify-collections"

--- a/src/workflows/migrate-collections-from-shopify.ts
+++ b/src/workflows/migrate-collections-from-shopify.ts
@@ -1,0 +1,51 @@
+import { createWorkflow, transform, WorkflowResponse } from "@medusajs/framework/workflows-sdk"
+import { CreateProductCollectionDTO } from "@medusajs/framework/types"
+import { createCollectionsWorkflow, useQueryGraphStep } from "@medusajs/medusa/core-flows"
+import { getShopifyCollectionsStep } from "./steps/get-shopify-collections"
+
+export const migrateCollectionsFromShopifyWorkflowId = "migrate-collections-from-shopify"
+
+export const migrateCollectionsFromShopify = createWorkflow(
+  {
+    name: migrateCollectionsFromShopifyWorkflowId,
+    retentionTime: 10000,
+    store: true,
+  },
+  () => {
+    const collections = getShopifyCollectionsStep()
+
+    const handleFilters = transform({ collections }, (data) => {
+      return data.collections.map((c) => c.handle)
+    })
+
+    const { data: existingCollections } = useQueryGraphStep({
+      entity: "product_collection",
+      fields: ["id", "handle"],
+      filters: { handle: handleFilters },
+    }).config({ name: "get-existing-collections" })
+
+    const collectionsToCreate = transform(
+      { collections, existingCollections },
+      (data) => {
+        const result: CreateProductCollectionDTO[] = []
+        data.collections.forEach((coll) => {
+          const existing = data.existingCollections.find((c) => c.handle === coll.handle)
+          if (!existing) {
+            result.push({
+              title: coll.title,
+              handle: coll.handle,
+              metadata: { external_id: coll.id },
+            })
+          }
+        })
+        return result
+      }
+    )
+
+    createCollectionsWorkflow.runAsStep({
+      input: { collections: collectionsToCreate },
+    })
+
+    return new WorkflowResponse({ count: collections.length })
+  }
+)

--- a/src/workflows/migrate-products-from-shopify.ts
+++ b/src/workflows/migrate-products-from-shopify.ts
@@ -1,0 +1,96 @@
+import { createWorkflow, transform, WorkflowResponse } from "@medusajs/framework/workflows-sdk"
+import { CreateProductWorkflowInputDTO, UpsertProductDTO } from "@medusajs/framework/types"
+import { createProductsWorkflow, updateProductsWorkflow, useQueryGraphStep } from "@medusajs/medusa/core-flows"
+import { getShopifyProductsStep } from "./steps/get-shopify-products"
+
+export const migrateProductsFromShopifyWorkflowId = "migrate-products-from-shopify"
+
+export const migrateProductsFromShopify = createWorkflow(
+  {
+    name: migrateProductsFromShopifyWorkflowId,
+    retentionTime: 10000,
+    store: true,
+  },
+  () => {
+    const products = getShopifyProductsStep()
+
+    const { data: stores } = useQueryGraphStep({
+      entity: "store",
+      fields: ["supported_currencies.*", "default_sales_channel_id"],
+      pagination: { take: 1, skip: 0 },
+    })
+
+
+    const externalIdFilters = transform({ products }, (data) => {
+      return data.products.map((p) => p.id)
+    })
+
+    const { data: existingProducts } = useQueryGraphStep({
+      entity: "product",
+      fields: ["id", "external_id", "variants.id", "variants.metadata"],
+      filters: { external_id: externalIdFilters },
+    }).config({ name: "get-existing-products" })
+
+    const { productsToCreate, productsToUpdate } = transform(
+      { products, stores, existingProducts },
+      (data) => {
+        const toCreate = new Map<string, CreateProductWorkflowInputDTO>()
+        const toUpdate = new Map<string, UpsertProductDTO>()
+
+        data.products.forEach((shopifyProduct) => {
+          const existing = data.existingProducts.find((p) => p.external_id === shopifyProduct.id)
+          const productData: CreateProductWorkflowInputDTO | UpsertProductDTO = {
+            title: shopifyProduct.title,
+            description: shopifyProduct.descriptionHtml || undefined,
+            status: "published",
+            handle: `${shopifyProduct.title.toLowerCase().replace(/\s+/g, "-")}-${shopifyProduct.id}`,
+            external_id: shopifyProduct.id,
+            sales_channels: [{ id: data.stores[0].default_sales_channel_id }],
+            images: shopifyProduct.images.map((img) => ({
+              url: img.url,
+              metadata: { external_id: img.id },
+            })),
+            variants: shopifyProduct.variants.map((variant) => {
+              const existingVariant = existing?.variants.find(
+                (v) => v.metadata?.external_id === variant.id
+              )
+              return {
+                id: existingVariant?.id,
+                title: variant.title,
+                sku: variant.sku || undefined,
+                prices: data.stores[0].supported_currencies.map(({ currency_code }) => ({
+                  amount: parseFloat(variant.price),
+                  currency_code,
+                })),
+                inventory_quantity: variant.inventoryQuantity ?? 0,
+                metadata: { external_id: variant.id },
+              }
+            }),
+          }
+
+          if (existing) {
+            productData.id = existing.id
+            toUpdate.set(existing.id, productData as UpsertProductDTO)
+          } else {
+            toCreate.set(shopifyProduct.id, productData as CreateProductWorkflowInputDTO)
+          }
+        })
+
+        return {
+          productsToCreate: Array.from(toCreate.values()),
+          productsToUpdate: Array.from(toUpdate.values()),
+        }
+      }
+    )
+
+    createProductsWorkflow.runAsStep({
+      input: { products: productsToCreate },
+    })
+
+    updateProductsWorkflow.runAsStep({
+      input: { products: productsToUpdate },
+    })
+
+    return new WorkflowResponse({ count: products.length })
+  }
+)

--- a/src/workflows/steps/get-shopify-collections.ts
+++ b/src/workflows/steps/get-shopify-collections.ts
@@ -1,0 +1,12 @@
+import { createStep, StepResponse } from "@medusajs/framework/workflows-sdk"
+import ShopifyService from "../../modules/shopify/service"
+import { SHOPIFY_MODULE } from "../../modules/shopify"
+
+export const getShopifyCollectionsStep = createStep({
+  name: "get-shopify-collections",
+  async: true,
+}, async ({}, { container }) => {
+  const shopifyService: ShopifyService = container.resolve(SHOPIFY_MODULE)
+  const collections = await shopifyService.getCollections()
+  return new StepResponse(collections)
+})

--- a/src/workflows/steps/get-shopify-products.ts
+++ b/src/workflows/steps/get-shopify-products.ts
@@ -1,0 +1,12 @@
+import { createStep, StepResponse } from "@medusajs/framework/workflows-sdk"
+import ShopifyService from "../../modules/shopify/service"
+import { SHOPIFY_MODULE } from "../../modules/shopify"
+
+export const getShopifyProductsStep = createStep({
+  name: "get-shopify-products",
+  async: true,
+}, async ({}, { container }) => {
+  const shopifyService: ShopifyService = container.resolve(SHOPIFY_MODULE)
+  const products = await shopifyService.getProducts()
+  return new StepResponse(products)
+})


### PR DESCRIPTION
## Summary
- add `getCollections` method in Shopify service
- fetch collections in a dedicated workflow step
- migrate Shopify collections to Medusa product collections
- export the new workflow and step

## Testing
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_6849487f838083288bf48b21dcc8723e