### PR TITLE
Add Shopify admin migration UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,7 @@ Join our [Discord server](https://discord.com/invite/medusajs) to meet other com
 - [Twitter](https://twitter.com/medusajs)
 - [LinkedIn](https://www.linkedin.com/company/medusajs)
 - [Medusa Blog](https://medusajs.com/blog/)
+
+## Test it Out
+
+After building and linking the plugin in a Medusa project, open the Medusa Admin at `http://localhost:9000/app`. A new sidebar item "Shopify Migration" should appear. Click on it to run product or collection migrations from Shopify.

--- a/src/admin/components/migration-form.tsx
+++ b/src/admin/components/migration-form.tsx
@@ -1,0 +1,115 @@
+import { Button, Checkbox, Drawer, Label, toast } from "@medusajs/ui"
+import { useForm, FormProvider, Controller } from "react-hook-form"
+import { z } from "zod"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { sdk } from "../lib/sdk"
+
+type MigrationType = "collection" | "product"
+
+const schema = z.object({
+  type: z.enum(["collection", "product"]).array()
+})
+
+export const MigrationForm = () => {
+  const queryClient = useQueryClient()
+  const form = useForm<z.infer<typeof schema>>({
+    defaultValues: {
+      type: ["product", "collection"],
+    },
+  })
+
+  const { mutateAsync } = useMutation({
+    mutationFn: () =>
+      sdk.client.fetch("/admin/shopify/migrations", {
+        method: "post",
+        body: {
+          type: form.getValues().type,
+        },
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["shopify"],
+      })
+      toast.success("Migration started")
+    },
+    onError: (e) => {
+      toast.error(e.message)
+    },
+  })
+
+  const handleSubmit = form.handleSubmit(async () => {
+    await mutateAsync()
+  })
+
+  const onCheckboxChange = (type: MigrationType) => {
+    form.setValue(
+      "type",
+      form.getValues().type.includes(type)
+        ? (form.getValues().type.filter((v) => v !== type) as MigrationType[])
+        : ([...form.getValues().type, type] as MigrationType[])
+    )
+  }
+
+  return (
+    <Drawer.Content>
+      <FormProvider {...form}>
+        <form onSubmit={handleSubmit} className="flex h-full flex-col overflow-hidden">
+          <Drawer.Header>
+            <Drawer.Title>Migrate Data from Shopify</Drawer.Title>
+          </Drawer.Header>
+          <Drawer.Body className="p-4">
+            <Controller
+              control={form.control}
+              name="type"
+              render={({ field }) => {
+                return (
+                  <div className="flex flex-col space-y-2">
+                    <div className="flex items-center gap-x-1">
+                      <Label size="small" weight="plus">
+                        Type
+                      </Label>
+                    </div>
+                    <div className="flex items-center space-x-2">
+                      <Checkbox
+                        id="collection"
+                        checked={field.value.includes("collection")}
+                        onCheckedChange={() => {
+                          onCheckboxChange("collection")
+                        }}
+                      />
+                      <Label htmlFor="collection">Collection</Label>
+                    </div>
+                    <div className="flex items-center space-x-2">
+                      <Checkbox
+                        id="product"
+                        checked={field.value.includes("product")}
+                        onCheckedChange={() => {
+                          onCheckboxChange("product")
+                        }}
+                      />
+                      <Label htmlFor="product">Product</Label>
+                    </div>
+                  </div>
+                )
+              }}
+            />
+          </Drawer.Body>
+          <Drawer.Footer>
+            <div className="flex items-center justify-end gap-x-2">
+              <Drawer.Close asChild>
+                <Button size="small" variant="secondary">
+                  Cancel
+                </Button>
+              </Drawer.Close>
+              <Drawer.Close asChild>
+                <Button type="submit" size="small">
+                  Migrate
+                </Button>
+              </Drawer.Close>
+            </div>
+          </Drawer.Footer>
+        </form>
+      </FormProvider>
+    </Drawer.Content>
+  )
+}

--- a/src/admin/lib/sdk.ts
+++ b/src/admin/lib/sdk.ts
@@ -1,0 +1,9 @@
+import Medusa from "@medusajs/js-sdk"
+
+export const sdk = new Medusa({
+  baseUrl: import.meta.env.VITE_BACKEND_URL || "/",
+  debug: import.meta.env.DEV,
+  auth: {
+    type: "session",
+  },
+})

--- a/src/admin/routes/shopify/page.tsx
+++ b/src/admin/routes/shopify/page.tsx
@@ -1,0 +1,78 @@
+import { defineRouteConfig } from "@medusajs/admin-sdk"
+import { ArrowDownTray } from "@medusajs/icons"
+import { Badge, Button, Container, DataTable, Drawer, Heading, Toaster, createDataTableColumnHelper, useDataTable } from "@medusajs/ui"
+import { HttpTypes } from "@medusajs/framework/types"
+import { useQuery } from "@tanstack/react-query"
+import { sdk } from "../../lib/sdk"
+import { MigrationForm } from "../../components/migration-form"
+
+const columnHelper = createDataTableColumnHelper<HttpTypes.AdminWorkflowExecution>()
+
+const columns = [
+  columnHelper.accessor("id", {
+    header: "ID",
+  }),
+  columnHelper.accessor("workflow_id", {
+    header: "Workflow ID",
+  }),
+  columnHelper.accessor("state", {
+    header: "State",
+    cell: ({ getValue }) => {
+      const state = getValue()
+      return (
+        <Badge color={state === "done" ? "green" : state === "failed" ? "red" : "grey"} size="xsmall">
+          {state}
+        </Badge>
+      )
+    },
+  }),
+  columnHelper.accessor("created_at", {
+    header: "Date",
+    cell: ({ getValue }) => {
+      const date = new Date(getValue())
+      return date.toLocaleDateString()
+    },
+  }),
+]
+
+const CustomPage = () => {
+  const { data, isLoading } = useQuery<{ workflow_executions: HttpTypes.AdminWorkflowExecution[]; count: number }>({
+    queryFn: async () => sdk.client.fetch("/admin/shopify/migrations"),
+    queryKey: ["shopify"],
+  })
+
+  const table = useDataTable({
+    columns,
+    data: data?.workflow_executions || [],
+    getRowId: (row) => row.id,
+    rowCount: data?.count || 0,
+    isLoading,
+  })
+
+  return (
+    <Container className="divide-y p-0">
+      <DataTable instance={table}>
+        <DataTable.Toolbar className="flex flex-col items-start justify-between gap-2 md:flex-row md:items-center">
+          <Heading>Migrations</Heading>
+          <div className="flex gap-2">
+            <Drawer>
+              <Drawer.Trigger asChild>
+                <Button>Migrate Data</Button>
+              </Drawer.Trigger>
+              <MigrationForm />
+            </Drawer>
+          </div>
+        </DataTable.Toolbar>
+        <DataTable.Table />
+      </DataTable>
+      <Toaster />
+    </Container>
+  )
+}
+
+export const config = defineRouteConfig({
+  label: "Shopify Migration",
+  icon: ArrowDownTray,
+})
+
+export default CustomPage

--- a/src/api/middlewares.ts
+++ b/src/api/middlewares.ts
@@ -1,0 +1,18 @@
+import { defineMiddlewares, validateAndTransformBody } from "@medusajs/framework/http"
+import { z } from "zod"
+
+export const AdminShopifyMigrationsPost = z.object({
+  type: z.enum(["collection", "product"]).array()
+})
+
+export default defineMiddlewares({
+  routes: [
+    {
+      matcher: "/admin/shopify/migrations",
+      method: "POST",
+      middlewares: [
+        validateAndTransformBody(AdminShopifyMigrationsPost)
+      ]
+    }
+  ]
+})

--- a/src/jobs/migrate-shopify.ts
+++ b/src/jobs/migrate-shopify.ts
@@ -1,0 +1,17 @@
+import { MedusaContainer } from "@medusajs/framework/types"
+
+export default async function migrateShopifyJob(container: MedusaContainer) {
+  const eventBusService = container.resolve("event_bus")
+
+  eventBusService.emit({
+    name: "migrate.shopify",
+    data: {
+      type: ["product", "collection"],
+    },
+  })
+}
+
+export const config = {
+  name: "migrate-shopify-job",
+  schedule: "0 0 * * *",
+}

--- a/src/subscribers/migrate-shopify.ts
+++ b/src/subscribers/migrate-shopify.ts
@@ -1,0 +1,36 @@
+import type { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
+import { migrateCollectionsFromShopify, migrateProductsFromShopify } from "../workflows"
+import { promiseAll } from "@medusajs/framework/utils"
+
+type Payload = {
+  type: ("product" | "collection")[]
+}
+
+export default async function migrateShopifyHandler({
+  event: { data },
+  container,
+}: SubscriberArgs<Payload>) {
+  const logger = container.resolve("logger")
+  await promiseAll(
+    data.type.map(async (type) => {
+      switch (type) {
+        case "product":
+          logger.info("Migrating products from Shopify...")
+          await migrateProductsFromShopify(container).run()
+          break
+        case "collection":
+          logger.info("Migrating collections from Shopify...")
+          await migrateCollectionsFromShopify(container).run()
+          break
+        default:
+          console.log(`Unknown type: ${type}`)
+      }
+    })
+  )
+
+  console.log("Finished migration from Shopify")
+}
+
+export const config: SubscriberConfig = {
+  event: "migrate.shopify",
+}

--- a/src/workflows/index.ts
+++ b/src/workflows/index.ts
@@ -1,0 +1,4 @@
+export * from "./migrate-products-from-shopify"
+export * from "./steps/get-shopify-products"
+export * from "./migrate-collections-from-shopify"
+export * from "./steps/get-shopify-collections"

--- a/src/workflows/migrate-collections-from-shopify.ts
+++ b/src/workflows/migrate-collections-from-shopify.ts
@@ -1,0 +1,51 @@
+import { createWorkflow, transform, WorkflowResponse } from "@medusajs/framework/workflows-sdk"
+import { CreateProductCollectionDTO } from "@medusajs/framework/types"
+import { createCollectionsWorkflow, useQueryGraphStep } from "@medusajs/medusa/core-flows"
+import { getShopifyCollectionsStep } from "./steps/get-shopify-collections"
+
+export const migrateCollectionsFromShopifyWorkflowId = "migrate-collections-from-shopify"
+
+export const migrateCollectionsFromShopify = createWorkflow(
+  {
+    name: migrateCollectionsFromShopifyWorkflowId,
+    retentionTime: 10000,
+    store: true,
+  },
+  () => {
+    const collections = getShopifyCollectionsStep()
+
+    const handleFilters = transform({ collections }, (data) => {
+      return data.collections.map((c) => c.handle)
+    })
+
+    const { data: existingCollections } = useQueryGraphStep({
+      entity: "product_collection",
+      fields: ["id", "handle"],
+      filters: { handle: handleFilters },
+    }).config({ name: "get-existing-collections" })
+
+    const collectionsToCreate = transform(
+      { collections, existingCollections },
+      (data) => {
+        const result: CreateProductCollectionDTO[] = []
+        data.collections.forEach((coll) => {
+          const existing = data.existingCollections.find((c) => c.handle === coll.handle)
+          if (!existing) {
+            result.push({
+              title: coll.title,
+              handle: coll.handle,
+              metadata: { external_id: coll.id },
+            })
+          }
+        })
+        return result
+      }
+    )
+
+    createCollectionsWorkflow.runAsStep({
+      input: { collections: collectionsToCreate },
+    })
+
+    return new WorkflowResponse({ count: collections.length })
+  }
+)

--- a/src/workflows/migrate-products-from-shopify.ts
+++ b/src/workflows/migrate-products-from-shopify.ts
@@ -1,0 +1,96 @@
+import { createWorkflow, transform, WorkflowResponse } from "@medusajs/framework/workflows-sdk"
+import { CreateProductWorkflowInputDTO, UpsertProductDTO } from "@medusajs/framework/types"
+import { createProductsWorkflow, updateProductsWorkflow, useQueryGraphStep } from "@medusajs/medusa/core-flows"
+import { getShopifyProductsStep } from "./steps/get-shopify-products"
+
+export const migrateProductsFromShopifyWorkflowId = "migrate-products-from-shopify"
+
+export const migrateProductsFromShopify = createWorkflow(
+  {
+    name: migrateProductsFromShopifyWorkflowId,
+    retentionTime: 10000,
+    store: true,
+  },
+  () => {
+    const products = getShopifyProductsStep()
+
+    const { data: stores } = useQueryGraphStep({
+      entity: "store",
+      fields: ["supported_currencies.*", "default_sales_channel_id"],
+      pagination: { take: 1, skip: 0 },
+    })
+
+
+    const externalIdFilters = transform({ products }, (data) => {
+      return data.products.map((p) => p.id)
+    })
+
+    const { data: existingProducts } = useQueryGraphStep({
+      entity: "product",
+      fields: ["id", "external_id", "variants.id", "variants.metadata"],
+      filters: { external_id: externalIdFilters },
+    }).config({ name: "get-existing-products" })
+
+    const { productsToCreate, productsToUpdate } = transform(
+      { products, stores, existingProducts },
+      (data) => {
+        const toCreate = new Map<string, CreateProductWorkflowInputDTO>()
+        const toUpdate = new Map<string, UpsertProductDTO>()
+
+        data.products.forEach((shopifyProduct) => {
+          const existing = data.existingProducts.find((p) => p.external_id === shopifyProduct.id)
+          const productData: CreateProductWorkflowInputDTO | UpsertProductDTO = {
+            title: shopifyProduct.title,
+            description: shopifyProduct.descriptionHtml || undefined,
+            status: "published",
+            handle: `${shopifyProduct.title.toLowerCase().replace(/\s+/g, "-")}-${shopifyProduct.id}`,
+            external_id: shopifyProduct.id,
+            sales_channels: [{ id: data.stores[0].default_sales_channel_id }],
+            images: shopifyProduct.images.map((img) => ({
+              url: img.url,
+              metadata: { external_id: img.id },
+            })),
+            variants: shopifyProduct.variants.map((variant) => {
+              const existingVariant = existing?.variants.find(
+                (v) => v.metadata?.external_id === variant.id
+              )
+              return {
+                id: existingVariant?.id,
+                title: variant.title,
+                sku: variant.sku || undefined,
+                prices: data.stores[0].supported_currencies.map(({ currency_code }) => ({
+                  amount: parseFloat(variant.price),
+                  currency_code,
+                })),
+                inventory_quantity: variant.inventoryQuantity ?? 0,
+                metadata: { external_id: variant.id },
+              }
+            }),
+          }
+
+          if (existing) {
+            productData.id = existing.id
+            toUpdate.set(existing.id, productData as UpsertProductDTO)
+          } else {
+            toCreate.set(shopifyProduct.id, productData as CreateProductWorkflowInputDTO)
+          }
+        })
+
+        return {
+          productsToCreate: Array.from(toCreate.values()),
+          productsToUpdate: Array.from(toUpdate.values()),
+        }
+      }
+    )
+
+    createProductsWorkflow.runAsStep({
+      input: { products: productsToCreate },
+    })
+
+    updateProductsWorkflow.runAsStep({
+      input: { products: productsToUpdate },
+    })
+
+    return new WorkflowResponse({ count: products.length })
+  }
+)

--- a/src/workflows/steps/get-shopify-collections.ts
+++ b/src/workflows/steps/get-shopify-collections.ts
@@ -1,0 +1,12 @@
+import { createStep, StepResponse } from "@medusajs/framework/workflows-sdk"
+import ShopifyService from "../../modules/shopify/service"
+import { SHOPIFY_MODULE } from "../../modules/shopify"
+
+export const getShopifyCollectionsStep = createStep({
+  name: "get-shopify-collections",
+  async: true,
+}, async ({}, { container }) => {
+  const shopifyService: ShopifyService = container.resolve(SHOPIFY_MODULE)
+  const collections = await shopifyService.getCollections()
+  return new StepResponse(collections)
+})

--- a/src/workflows/steps/get-shopify-products.ts
+++ b/src/workflows/steps/get-shopify-products.ts
@@ -1,0 +1,12 @@
+import { createStep, StepResponse } from "@medusajs/framework/workflows-sdk"
+import ShopifyService from "../../modules/shopify/service"
+import { SHOPIFY_MODULE } from "../../modules/shopify"
+
+export const getShopifyProductsStep = createStep({
+  name: "get-shopify-products",
+  async: true,
+}, async ({}, { container }) => {
+  const shopifyService: ShopifyService = container.resolve(SHOPIFY_MODULE)
+  const products = await shopifyService.getProducts()
+  return new StepResponse(products)
+})


### PR DESCRIPTION
## Summary
- add admin SDK page for Shopify migrations
- expose route to list and trigger migrations
- validate requests with middleware
- schedule job and subscriber to run migrations
- document how to test the plugin in README

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_6849487f838083288bf48b21dcc8723e